### PR TITLE
Document AWS permissions

### DIFF
--- a/AWS-permissions.md
+++ b/AWS-permissions.md
@@ -1,0 +1,53 @@
+Here are the IAM permissions that 7777 requires to run correctly:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:DetachRolePolicy",
+                "iam:AttachRolePolicy",
+                "logs:CreateLogGroup",
+                "logs:PutRetentionPolicy",
+                "logs:DeleteLogGroup",
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "rds:DescribeDBSubnetGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:createTags",
+                "ecs:DescribeClusters",
+                "ecs:CreateCluster",
+                "ecs:DeleteCluster",
+                "ecs:DescribeTasks",
+                "ecs:RunTask",
+                "ecs:StopTask",
+                "ecs:RegisterTaskDefinition",
+                "ecs:DeregisterTaskDefinition",
+                "cloudformation:GetTemplate",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:DescribeStacks",
+                "cloudformation:DeleteStack"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ If you prefer, you also can provide AWS access keys explicitly via the following
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 
+You can find [the list of IAM permissions here](AWS-permissions.md) if you create access keys specific to 7777.
+
 ## Usage
 
 To use 7777 to connect to an AWS RDS database, simply run `7777`:


### PR DESCRIPTION
Some users may prefer to setup specific AWS access keys for 7777, here is the list of IAM permissions to use.